### PR TITLE
Follow-up meeting to be held on 02.11.2017 at 14:00

### DIFF
--- a/20171102/AGENDA.md
+++ b/20171102/AGENDA.md
@@ -2,7 +2,7 @@
 To be held on 02.11.2017 at 14:00
 
 # Agenda
-1. Introduce <feature/limitation> and share experience about it.
+1. Introduce "General Hooks" feature and share experience about it.
 2. Report user's experience - round table.
 3. Propose new development, enhancement or bug fix, for collaborative
    development

--- a/20171102/AGENDA.md
+++ b/20171102/AGENDA.md
@@ -1,0 +1,9 @@
+# Sardana follow-up meeting
+To be held on 02.11.2017 at 14:00
+
+# Agenda
+1. Introduce <feature/limitation> and share experience about it.
+2. Report user's experience - round table.
+3. Propose new development, enhancement or bug fix, for collaborative
+   development
+4. Any other topic...

--- a/20171102/AGENDA.md
+++ b/20171102/AGENDA.md
@@ -6,4 +6,5 @@ To be held on 02.11.2017 at 14:00
 2. Report user's experience - round table.
 3. Propose new development, enhancement or bug fix, for collaborative
    development
-4. Any other topic...
+4. Try to share the pending PR between the integrators.
+5. Any other topic...


### PR DESCRIPTION
This will be the first Sardan follow-up meeting. We will still not announce it for the whole community just to test the format of the meeting. The invitet partcipants are @teresanunez, @amilan, @daneos and myself.