### PR TITLE
Add Sardana Workshop 2018 (Prague) agenda

### DIFF
--- a/20180605-Prague/AGENDA.md
+++ b/20180605-Prague/AGENDA.md
@@ -1,0 +1,47 @@
+# Sardana and Taurus Workshop 2018
+
+As in some previous occasions we take a profit of the annual Tango 
+meetings and organize a satellite Sardana and Taurus workshop. This time the 
+workshop will be held in parallel to the Tango Steering Committee meeting.
+
+Since the available time is very limited we do not foresee to introduce 
+Sardana and Taurus to the newcomers but will directly start with the 
+overview of the newest features/issues. 
+
+More information about the venue can be found on the 32nd Tango 
+Collaboration Meeting [site](https://indico.eli-beams.eu/event/310/page/0)
+
+If you need any information, please contact:
+Zbigniew Reszela (zreszela@cells.es) or Carlos Pascual (cpascual@cells.es)
+
+## Agenda
+
+8:30 - 8:35 - Welcome 
+
+8:35 - 8:50 - Macro logging (15 min) - Teresa (DESY)
+
+8:50 - 9:05 - Sardana logging with Elastic stack (15 min) - Grzegorz 
+(SOLARIS) and Antonio (MAXIV)
+
+9:05 - 9:20 - General hooks (15 min) - Teresa
+
+9:20 - 9:45 - Diffractometer control (25 min) - Teresa
+
+9:45 - 10:30 - Continuous Scans (45 min) - Zibi (ALBA)
+
+10:30 - 10:45 - Coffee break
+
+10:45 - 11:10 - 2D detectors (25 min) - Zibi
+
+11:10 - 11:40 - Taurus eval scheme (30 min) - Carlos (ALBA)
+
+11:50 - 12:00 - Plots with pyqtgraph (10 min) - Carlos
+
+12:00 - 12:15 - Taurus Custom Formatters (15 min) - Carlos
+
+12:15 - 12:25 - Recent bug fixes in Taurus that may affect existing codes:
+                #511, #512, #678, #738, ... (10 min) - Carlos
+
+12:25 - 12:30 - Closure
+
+12:30 - 13:30 - Lunch


### PR DESCRIPTION
This is basically the agenda agreed during the last appear.in call on 19.04.2018.
There were just some cosmetic changes regarding the Taurus presentations.

Please accept/correct it so we could link it from the Tango Meeting page ASAP.