### PR TITLE
Add agenda for community followup meeting 20210923

### DIFF
--- a/20210923/AGENDA.md
+++ b/20210923/AGENDA.md
@@ -4,38 +4,28 @@ To be held on Thursday 2021/09/23 at 14:00
 
 ## Agenda
 
-1. Urgent user problems/issues - Round table
+1. Presentation by Teresa of the Sardana configuration tool used at DESY.
 
-2. Review pending points from the previous meeting
+2. Urgent user problems/issues - Round table
+
+3. Review pending points from the previous meeting
      - From previous meetings:
         - [ ] MacroServer startup hook (that would be called automatically after starting the server - an opposite to the atexit)
               - Zibi wanted to create a PR
-        - [ ] Alba EM plugin
-	      - Johan wanted to have a look to the PR
         - [ ] Wrong time estimation in continuous scans reported by beamline scientists - calculation methods need to be reviewed (as we show it to the users
         it needs to be accurate) 
               - Not high priority for ALBA anymore to review these calculations.
-        - [ ] Before starting the scan, Sardana should verify the states of measurement channels.
         - [ ] MaxIV beats configuration status:
             - there are some unsolved issues with distinguishing timestamps (on the level of milisecs) in Sardana logs by Elastic - more investigation is needed
         - [ ] Users can break Sardana by messing with configuration in Tango DB:
-	    - status of the diagnostics script
+     	    - status of the diagnostics script
         - [ ] Hang scan due to the counter/timer controller timeout in StateOne() - How to deal with exceptions in the controllers: Review the docs?
       
-3. Overview of current developments / PR distribution
-    - Macro plots appear twice in QtSpock [#1570](https://github.com/sardana-org/sardana/issues/1570)
-      - Bug or feature?
-    - Create controller from a Macroserver with two pools [#589](https://github.com/sardana-org/sardana/issues/589)
-      - Design proposed. Any volunteers to work on that?
-    - Consider removing dtype from the measurement group configuration [#1561](https://github.com/sardana-org/sardana/issues/1561)
-      - Anyone knows on recorders usign this information?
-    - Refractor hooks for move macros [#1544](https://github.com/sardana-org/sardana/pull/1544)
-    - Last scan macro data http://github.com/sardana-org/sardana/issues/290#issuecomment-819440784
+4. Overview of current developments / PR distribution
     - sardana CLI [#286](https://github.com/sardana-org/sardana/issues/286)
       - Johan wanted to work on that
-    - Not possible to call mAPI methods (macro API) after stopping/aborting a macro (SF#9) [#10](https://github.com/sardana-org/sardana/issues/10)
     - General Conditions [#1481](https://github.com/sardana-org/sardana/pull/1481)
     
-4. Migration to gitlab and rename master branch to main/stable.
+5. Migration to gitlab and rename master branch to main/stable.
 
-5. AOB
+6. AOB

--- a/20210923/AGENDA.md
+++ b/20210923/AGENDA.md
@@ -28,4 +28,6 @@ To be held on Thursday 2021/09/23 at 14:00
     
 5. Migration to gitlab and rename master branch to main/stable.
 
-6. AOB
+6. Sardana release 3.2 (Jul21 milestone)
+
+7. AOB

--- a/20210923/AGENDA.md
+++ b/20210923/AGENDA.md
@@ -1,0 +1,41 @@
+# Sardana Follow-up Meeting - 2021/09/23
+
+To be held on Thursday 2021/09/23 at 14:00
+
+## Agenda
+
+1. Urgent user problems/issues - Round table
+
+2. Review pending points from the previous meeting
+     - From previous meetings:
+        - [ ] MacroServer startup hook (that would be called automatically after starting the server - an opposite to the atexit)
+              - Zibi wanted to create a PR
+        - [ ] Alba EM plugin
+	      - Johan wanted to have a look to the PR
+        - [ ] Wrong time estimation in continuous scans reported by beamline scientists - calculation methods need to be reviewed (as we show it to the users
+        it needs to be accurate) 
+              - Not high priority for ALBA anymore to review these calculations.
+        - [ ] Before starting the scan, Sardana should verify the states of measurement channels.
+        - [ ] MaxIV beats configuration status:
+            - there are some unsolved issues with distinguishing timestamps (on the level of milisecs) in Sardana logs by Elastic - more investigation is needed
+        - [ ] Users can break Sardana by messing with configuration in Tango DB:
+	    - status of the diagnostics script
+        - [ ] Hang scan due to the counter/timer controller timeout in StateOne() - How to deal with exceptions in the controllers: Review the docs?
+      
+3. Overview of current developments / PR distribution
+    - Macro plots appear twice in QtSpock [#1570](https://github.com/sardana-org/sardana/issues/1570)
+      - Bug or feature?
+    - Create controller from a Macroserver with two pools [#589](https://github.com/sardana-org/sardana/issues/589)
+      - Design proposed. Any volunteers to work on that?
+    - Consider removing dtype from the measurement group configuration [#1561](https://github.com/sardana-org/sardana/issues/1561)
+      - Anyone knows on recorders usign this information?
+    - Refractor hooks for move macros [#1544](https://github.com/sardana-org/sardana/pull/1544)
+    - Last scan macro data http://github.com/sardana-org/sardana/issues/290#issuecomment-819440784
+    - sardana CLI [#286](https://github.com/sardana-org/sardana/issues/286)
+      - Johan wanted to work on that
+    - Not possible to call mAPI methods (macro API) after stopping/aborting a macro (SF#9) [#10](https://github.com/sardana-org/sardana/issues/10)
+    - General Conditions [#1481](https://github.com/sardana-org/sardana/pull/1481)
+    
+4. Migration to gitlab and rename master branch to main/stable.
+
+5. AOB


### PR DESCRIPTION
Kept most items from last meeting (20210610) but removed a few things
that were either specific to that meeting or where the linked issue/PR
was closed.